### PR TITLE
Corrige uso obsoleto de File.exists? no Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure('2') do |config|
 
   config.vm.box_check_update = false
 
-        if !(File.exists?('id_rsa'))
+        if !(File.exist?('id_rsa'))
           system("ssh-keygen -b 2048 -t rsa -f id_rsa -q -N ''")
        end
 


### PR DESCRIPTION
Substitui `File.exists?('id_rsa')` por `File.exist?('id_rsa')` na linha 14 do `Vagrantfile`.

O método `File.exists?` está obsoleto desde o Ruby 2.1 e foi removido em versões mais recentes. A versão correta e atual é `File.exist?`.

Essa mudança evita warnings ou falhas em ambientes com versões mais recentes do Ruby.